### PR TITLE
Modify post install message

### DIFF
--- a/arangodb.install
+++ b/arangodb.install
@@ -69,7 +69,7 @@ post_upgrade() {
   with the upgrade option:
 
     sudo systemctl stop arangodb.service
-    sudo arangod --upgrade
+    sudo arangod --database.auto-upgrade
     sudo systemctl start arangodb.service
 
   Take a look at the Changelog to see what is new in $1:


### PR DESCRIPTION
Here is the message arangod gives when using only --upgrade
"Please note that the specified option '--upgrade' has been renamed to '--database.auto-upgrade' in this ArangoDB version"
So I changed the post-install message accordingly.
